### PR TITLE
kinto-heroku doesn't yet support kinto version 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kinto
+kinto<3.0
 SQLAlchemy
 psycopg2>2.5
 zope.sqlalchemy


### PR DESCRIPTION
This is because the config file kinto.ini has some cliquet settings in it which have been removed in kinto version 3.0.0.

So, until we update kinto.ini to match the latest kinto version, let's just make it work with kinto 2.x for the time being