### PR TITLE
Generate an hmac secret, store it in an environment variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,5 +14,10 @@
   "repository": "https://github.com/kinto/kinto-heroku",
   "logo": "https://avatars0.githubusercontent.com/u/13413813",
   "scripts": {},
-  "env": {}
+  "env": {
+    "KINTO_USERID_HMAC_SECRET": {
+      "description": "The secret used to create the user ID from a username:password pair",
+      "generator": "secret"
+    }
+  }
 }

--- a/kinto.ini
+++ b/kinto.ini
@@ -10,6 +10,9 @@ kinto.storage_backend = cliquet.storage.postgresql
 kinto.cache_backend = cliquet.cache.postgresql
 kinto.permission_backend = cliquet.permission.postgresql
 
+# The hmac secret below gets overridden by the environment variable
+# KINTO_USERID_HMAC_SECRET which gets set on creation of the Heroku app
+# See the env section of app.json
 kinto.userid_hmac_secret = thisMUSTbeCHANGED
 multiauth.policies = basicauth
 # multiauth.policies = fxa basicauth


### PR DESCRIPTION
This will create a unique random hmac secret on installing the app on Heroku using the button.

This fixes https://github.com/Kinto/kinto-heroku/issues/3